### PR TITLE
Fix expression being dropped when expecting unit

### DIFF
--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -219,8 +219,8 @@ let rewrite_apply_lwt ~backend ~state ident args =
       take @@ fun lst -> return (Some (backend#join (suspend_list ~state lst)))
   (* Async primitives *)
   | "async" -> take @@ fun process_f -> return (Some (backend#async process_f))
-  | "pause" -> take @@ fun _unit -> return (Some (backend#pause ()))
-  | "wait" -> take @@ fun _unit -> return (Some (backend#wait ()))
+  | "pause" -> take @@ fun unit -> return (Some (backend#pause unit))
+  | "wait" -> take @@ fun unit -> return (Some (backend#wait unit))
   | "wakeup" | "wakeup_later" ->
       take @@ fun u ->
       take @@ fun arg -> return (Some (backend#wakeup u arg))
@@ -228,7 +228,7 @@ let rewrite_apply_lwt ~backend ~state ident args =
       take @@ fun p -> return (Some (backend#async (suspend ~state p)))
   | "task" ->
       add_comment state backend#cancel_message;
-      take @@ fun _unit -> return (Some (backend#wait ()))
+      take @@ fun unit -> return (Some (backend#wait unit))
   | "cancel" | "no_cancel" | "protected" | "on_cancel" | "wrap_in_cancelable" ->
       add_comment state backend#cancel_message;
       return None
@@ -257,7 +257,7 @@ let rewrite_apply_lwt ~backend ~state ident args =
       take @@ fun msg ->
       return (Some (mk_apply_simple [ "invalid_arg" ] [ msg ]))
   (* Keys *)
-  | "new_key" -> take @@ fun _unit -> return (Some (backend#key_new ()))
+  | "new_key" -> take @@ fun unit -> return (Some (backend#key_new unit))
   | "get" -> take @@ fun key -> return (Some (backend#key_get key))
   | "with_value" ->
       take @@ fun key ->
@@ -356,13 +356,13 @@ let rewrite_apply ~backend ~state full_ident args =
   | "Lwt_unix", "lstat" ->
       take @@ fun path -> return (Some (backend#path_stat ~follow:false path))
   | "Lwt_condition", "create" ->
-      take @@ fun _unit -> return (Some (backend#condition_create ()))
+      take @@ fun unit -> return (Some (backend#condition_create unit))
   | "Lwt_condition", "wait" ->
       take_lblopt "mutex" @@ fun mutex ->
       take @@ fun cond ->
       return (Some (rewrite_lwt_condition_wait ~backend ~state mutex cond))
   | "Lwt_mutex", "create" ->
-      take @@ fun _unit -> return (Some (backend#mutex_create ()))
+      take @@ fun unit -> return (Some (backend#mutex_create unit))
   | "Lwt_mutex", "lock" -> take @@ fun t -> return (Some (backend#mutex_lock t))
   | "Lwt_mutex", "unlock" ->
       take @@ fun t -> return (Some (backend#mutex_unlock t))

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -96,15 +96,15 @@ let eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var add_comment =
         (mk_exp_ident (fiber_ident "fork"))
         [ get_current_switch_arg (); (Nolabel, process_f) ]
 
-    method wait () =
+    method wait unit =
       add_comment
         "Translation is incomplete, [Promise.await] must be called on the \
          promise when it's part of control-flow.";
-      mk_apply_simple (promise_ident "create") [ mk_unit_val ]
+      mk_apply_simple (promise_ident "create") [ unit ]
 
     method wakeup u arg = mk_apply_simple (promise_ident "resolve") [ u; arg ]
     method join lst = mk_apply_simple (fiber_ident "all") [ lst ]
-    method pause () = mk_apply_simple (fiber_ident "yield") [ mk_unit_val ]
+    method pause unit = mk_apply_simple (fiber_ident "yield") [ unit ]
 
     method extra_opens =
       if !used_eio_std then [ mk_longident' [ "Eio"; "Std" ] ] else []
@@ -131,8 +131,8 @@ let eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var add_comment =
 
     method timeout_exn = mk_longident [ "Eio"; "Time"; "Timeout" ]
 
-    method condition_create () =
-      mk_apply_simple [ "Eio"; "Condition"; "create" ] [ mk_unit_val ]
+    method condition_create unit =
+      mk_apply_simple [ "Eio"; "Condition"; "create" ] [ unit ]
 
     method condition_wait mutex cond =
       mk_apply_simple [ "Eio"; "Condition"; "await" ] [ cond; mutex ]
@@ -151,8 +151,8 @@ let eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var add_comment =
 
     method state p = mk_apply_simple (promise_ident "peek") [ p ]
 
-    method mutex_create () =
-      mk_apply_simple [ "Eio"; "Mutex"; "create" ] [ mk_unit_val ]
+    method mutex_create unit =
+      mk_apply_simple [ "Eio"; "Mutex"; "create" ] [ unit ]
 
     method mutex_lock m = mk_apply_simple [ "Eio"; "Mutex"; "lock" ] [ m ]
     method mutex_unlock m = mk_apply_simple [ "Eio"; "Mutex"; "unlock" ] [ m ]
@@ -166,9 +166,7 @@ let eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var add_comment =
           (Nolabel, f);
         ]
 
-    method key_new () =
-      mk_apply_simple (fiber_ident "create_key") [ mk_unit_val ]
-
+    method key_new unit = mk_apply_simple (fiber_ident "create_key") [ unit ]
     method key_get key = mk_apply_simple (fiber_ident "get") [ key ]
 
     method key_with_value key val_opt f =

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -50,7 +50,7 @@ Make a writable directory tree:
     Lwt_unix.sleep (line 31 column 9)
     Lwt_unix.Timeout (line 37 column 15)
     Lwt_unix.with_timeout (line 35 column 16)
-  lib/test.ml: (179 occurrences)
+  lib/test.ml: (183 occurrences)
     Lwt (line 36 column 12)
     Lwt (line 55 column 18)
     Lwt (line 64 column 13)
@@ -97,6 +97,8 @@ Make a writable directory tree:
     Lwt.fail (line 109 column 9)
     Lwt.return_unit (line 182 column 24)
     Lwt.return_unit (line 183 column 28)
+    Lwt.return_unit (line 195 column 16)
+    Lwt.return_unit (line 196 column 11)
     Lwt.fail_with (line 110 column 9)
     Lwt.fail_invalid_arg (line 118 column 33)
     Lwt.wait (line 122 column 14)
@@ -148,6 +150,7 @@ Make a writable directory tree:
     Lwt.wrap (line 189 column 3)
     Lwt.wrap (line 191 column 9)
     Lwt.pause (line 114 column 9)
+    Lwt.pause (line 197 column 7)
     Lwt.(>>=) (line 32 column 3)
     Lwt.(>>=) (line 33 column 27)
     Lwt.(>>=) (line 59 column 3)
@@ -158,6 +161,7 @@ Make a writable directory tree:
     Lwt.(>>=) (line 88 column 3)
     Lwt.(>>=) (line 158 column 60)
     Lwt.(>>=) (line 162 column 20)
+    Lwt.(>>=) (line 197 column 3)
     Lwt.(=<<) (line 111 column 20)
     Lwt.(>|=) (line 32 column 37)
     Lwt.(>|=) (line 46 column 16)
@@ -563,10 +567,10 @@ Make a writable directory tree:
       (fun () -> x)
   
   let _ =
-    let t, u
+    let t, u =
+      Promise.create
         (* TODO: lwt-to-direct-style: Translation is incomplete, [Promise.await] must be called on the promise when it's part of control-flow. *)
-        =
-      Promise.create ()
+        ()
     in
     Fiber.fork ~sw
       (* TODO: lwt-to-direct-style: [sw] (of type Switch.t) must be propagated here. *)
@@ -615,11 +619,11 @@ Make a writable directory tree:
         x
         (* TODO: lwt-to-direct-style: This computation might not be suspended correctly. *))
   
-  let _
+  let _ =
+    Promise.create
       (* TODO: lwt-to-direct-style: Use [Switch] or [Cancel] for defining a cancellable context. *)
       (* TODO: lwt-to-direct-style: Translation is incomplete, [Promise.await] must be called on the promise when it's part of control-flow. *)
-      =
-    Promise.create ()
+      ()
   
   let _ =
     match Promise.peek x with
@@ -685,6 +689,7 @@ Make a writable directory tree:
     f ()
   
   let _ = (fun () -> ()) ()
+  let _f x = Fiber.yield (match x with Some _ -> () | _ -> ())
 
   $ cat lib/test.mli
   open Eio.Std

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
@@ -189,3 +189,9 @@ let _ =
   Lwt.wrap f
 
 let _ = Lwt.wrap (fun () -> ())
+
+let _f x =
+  (match x with
+   | Some _ -> Lwt.return_unit
+   | _ -> Lwt.return_unit)
+  >>= Lwt.pause


### PR DESCRIPTION
The argument passed to unit-expecting functions like `Lwt.pause`, `Lwt.wait`, etc.. was dropped and replaced by a plain `()` expression.

This is not so uncommon considering code like this:

    let f () =
      eval_to_unit >>= Lwt.pause

which gets first transformed to:

    let f () =
      Lwt.pause eval_to_unit

then, the expression is eventually dropped:

    let f () =
      Fiber.yield ()