### PR TITLE
Translate `Lwt.choose`

### DIFF
--- a/bin/ciao_lwt/to_direct_style/ast_rewrite.ml
+++ b/bin/ciao_lwt/to_direct_style/ast_rewrite.ml
@@ -210,12 +210,7 @@ let rewrite_apply_lwt ~backend ~state ident args =
       return (Some (rewrite_lwt_both ~backend ~state left right))
   | "pick" ->
       take @@ fun lst -> return (Some (backend#pick (suspend_list ~state lst)))
-  | "choose" ->
-      take @@ fun _lst ->
-      add_comment state
-        ("[Lwt.choose] can't be automatically translated."
-       ^ backend#choose_comment_hint);
-      return None
+  | "choose" -> take @@ fun lst -> return (Some (backend#choose lst))
   | "join" ->
       take @@ fun lst -> return (Some (backend#join (suspend_list ~state lst)))
   (* Async primitives *)
@@ -276,12 +271,8 @@ let rewrite_apply_lwt ~backend ~state ident args =
       take @@ fun rhs ->
       return (Some (rewrite_lwt_both ~backend ~state lhs rhs))
   | "<?>" ->
-      take @@ fun _lhs ->
-      take @@ fun _rhs ->
-      add_comment state
-        ("[<?>] can't be automatically translated."
-       ^ backend#choose_comment_hint);
-      return None
+      take @@ fun lhs ->
+      take @@ fun rhs -> return (Some (backend#choose (Exp.list [ lhs; rhs ])))
   | "wrap" ->
       take @@ fun f -> return (Some (Exp.apply f [ (Nolabel, mk_unit_val) ]))
   | _ -> return None

--- a/bin/ciao_lwt/to_logs/to_logs.ml
+++ b/bin/ciao_lwt/to_logs/to_logs.ml
@@ -100,10 +100,10 @@ let call_reporter r src level over k msgf =
 let mk_broadcast ~state:_ loggers =
   mk_let_var "broadcast_reporters" loggers @@ fun reporters_var ->
   mk_reporter (fun src level over k msgf ->
-      let f k r _unit = call_reporter r src level over k msgf in
+      let f k r () = call_reporter r src level over k msgf in
       let f =
         let open Mk_function in
-        mk_function (return f $ arg "k" $ arg "r" $ arg "_unit")
+        mk_function (return f $ arg "k" $ arg "r" $ arg_unit)
       in
       mk_apply_simple [ "List"; "fold_left" ]
         [ f; k; reporters_var; mk_unit_val ])

--- a/lib/ocamlformat_utils/ast_utils.ml
+++ b/lib/ocamlformat_utils/ast_utils.ml
@@ -90,15 +90,18 @@ module Mk_function : sig
       ]} *)
 
   type 'a t
-  type arg
+  type 'a arg
 
-  val arg : ?lbl:[ `Lbl | `Opt of expression option ] -> string -> arg
-  val ( $ ) : (expression -> 'a) t -> arg -> 'a t
+  val arg :
+    ?lbl:[ `Lbl | `Opt of expression option ] -> string -> expression arg
+
+  val arg_unit : unit arg
+  val ( $ ) : ('b -> 'a) t -> 'b arg -> 'a t
   val return : 'a -> 'a t
   val mk_function : ?typ:type_constraint -> expression t -> expression
 end = struct
   type 'a t = expr_function_param list * 'a
-  type arg = expr_function_param * expression
+  type 'a arg = expr_function_param * 'a
 
   let ( $ ) (params, body) (param, exp) = (param :: params, body exp)
   let return f = ([], f)
@@ -112,6 +115,8 @@ end = struct
     in
     let exp = mk_exp_var name and pat = Pat.var (mk_loc name) in
     (mk_function_param ?lbl ?def pat, exp)
+
+  let arg_unit = (mk_function_param mk_unit_pat, ())
 
   let mk_function ?typ (params, body) =
     Exp.function_ (List.rev params) typ (Pfunction_body body)

--- a/test/ciao_lwt/to_direct_style.t/run.t
+++ b/test/ciao_lwt/to_direct_style.t/run.t
@@ -313,11 +313,9 @@ Make a writable directory tree:
 
   $ ciao-lwt to-eio --migrate
   Formatted 4 files
-  Warning: lib/test.ml: 8 occurrences have not been rewritten.
+  Warning: lib/test.ml: 6 occurrences have not been rewritten.
     Lwt (line 55 column 18)
     Lwt_fmt (line 56 column 18)
-    Lwt.(<?>) (line 113 column 11)
-    Lwt.choose (line 115 column 9)
     Lwt_list.iteri_p (line 129 column 9)
     Lwt.Fail (line 147 column 5)
     Lwt.let* (line 163 column 21)
@@ -549,17 +547,23 @@ Make a writable directory tree:
   let _ = Fun.id x
   
   let _ =
-    x
-    (* TODO: ciao-lwt: [<?>] can't be automatically translated.Use Eio.Promise instead.  *)
-    <?> x
+    Fiber.any
+      (List.map
+         (fun p () -> Promise.await p)
+         [
+           x
+           (* TODO: ciao-lwt: The list [[ x; x ]] is expected to be a list of promises. Use [Fiber.fork_promise] to make a promise. *);
+           x;
+         ])
   
   let _ = Fiber.yield ()
   
   let _ =
-    Lwt.choose
-      (* TODO: ciao-lwt: [Lwt.choose] can't be automatically translated.Use Eio.Promise instead.  *)
-      (* TODO: ciao-lwt: [Lwt.choose] can't be automatically translated.Use Eio.Promise instead.  *)
-      [ x; x ]
+    Fiber.any
+      (List.map
+         (fun p () -> Promise.await p)
+         (* TODO: ciao-lwt: The list [[ x; x ]] is expected to be a list of promises. Use [Fiber.fork_promise] to make a promise. *)
+         [ x; x ])
   
   let _ =
     Fiber.all

--- a/test/ciao_lwt/to_logs.t/run.t
+++ b/test/ciao_lwt/to_logs.t/run.t
@@ -489,7 +489,7 @@
              Logs.report =
                (fun src level ~over k msgf ->
                  List.fold_left
-                   (fun k r _unit -> r.Logs.report src level ~over k msgf)
+                   (fun k r () -> r.Logs.report src level ~over k msgf)
                    k broadcast_reporters ());
            });
         Lwt.return ()
@@ -550,7 +550,7 @@
              Logs.report =
                (fun src level ~over k msgf ->
                  List.fold_left
-                   (fun k r _unit -> r.Logs.report src level ~over k msgf)
+                   (fun k r () -> r.Logs.report src level ~over k msgf)
                    k broadcast_reporters ());
            });
         Lwt.return ()


### PR DESCRIPTION
For Eio, it is translated to `Fiber.any` where the fibers wait on the given promises.
This means that it expects a list of promise and not a list of thunks like for `Lwt.pick`.
